### PR TITLE
Fixed checkbox flicker for dropdown feature filters.

### DIFF
--- a/apps/omar-ui-app/grails-app/assets/javascripts/omar/filter/filter.controller.es6
+++ b/apps/omar-ui-app/grails-app/assets/javascripts/omar/filter/filter.controller.es6
@@ -63,6 +63,76 @@ function (
         });
     };
 
+    /**
+     * This block is for handling when a checkbox is pressed on
+     * and should not change the check value passed through to
+     * the following functions
+     */
+    let tempID = [false, false, false, false];
+    let same = [false, false, false, false];
+
+    vm.switchCheckDown = function(name) {
+        switch( name ) {
+            case "countrycode":
+                tempID[0] = vm.countryCodeCheck;
+                setTimeout(function() {
+                    same[0] = tempID[0] === vm.countryCodeCheck;
+                    tempID[0] = vm.countryCodeCheck; }, 10);
+                break;
+            case "mission":
+                tempID[1] = vm.missionIdCheck;
+                setTimeout(function() {
+                    same[1] = tempID[1] === vm.missionIdCheck;
+                    tempID[1] = vm.missionIdCheck; }, 10);
+                break;
+            case "product":
+                tempID[2] = vm.productIdCheck;
+                setTimeout(function() {
+                    same[2] = tempID[2] === vm.productIdCheck;
+                    tempID[2] = vm.productIdCheck; }, 10);
+                break;
+            case "sensor":
+                tempID[3] = vm.sensorIdCheck;
+                setTimeout(function() {
+                    same[3] = tempID[3] === vm.sensorIdCheck;
+                    tempID[3] = vm.sensorIdCheck; }, 10);
+                break;
+            default:
+                return;
+        }
+    }
+
+    vm.doUpdateOnNoChange = function(name) {
+        switch( name ) {
+            case "countrycode":
+                if (same[0] && vm.countryCode != '')
+                    vm.updateFilterString();
+                else
+                    vm.countryCodeCheck = tempID[0];
+                break;
+            case "mission":
+                if (same[1] && vm.missionId != '')
+                    vm.updateFilterString();
+                else
+                    vm.missionIdCheck = tempID[1];
+                break;
+            case "product":
+                if (same[2] && vm.productId != '')
+                    vm.updateFilterString();
+                else
+                    vm.productIdCheck = tempID[2];
+                break;
+            case "sensor":
+                if (same[3] && vm.sensorId != '')
+                    vm.updateFilterString();
+                else
+                    vm.sensorIdCheck = tempID[3];
+                break;
+            default:
+                return;
+        }
+    }
+
 
     /**
      * generates $scope.videoData = res.data

--- a/apps/omar-ui-app/grails-app/views/views/map/_map.partial.html.gsp
+++ b/apps/omar-ui-app/grails-app/views/views/map/_map.partial.html.gsp
@@ -149,7 +149,8 @@
                                     <div class = "input-group input-group-sm">
                                         <span class = "input-group-addon">
                                             <input
-                                                    ng-change = "filter.updateFilterString()"
+                                                    ng-mousedown="filter.switchCheckDown('countrycode')"
+                                                    ng-change = "filter.doUpdateOnNoChange('countrycode')"
                                                     ng-checked = "!filter.imageryCheck ? false : filter.countryCodeCheck"
                                                     ng-disabled = "!filter.imageryCheck"
                                                     ng-model = "filter.countryCodeCheck"
@@ -227,7 +228,11 @@
                                 <div class = "col-md-12">
                                     <div class = "input-group input-group-sm">
                                         <span class = "input-group-addon">
-                                            <input ng-change = "filter.updateFilterString()" ng-model = "filter.missionIdCheck" type="checkbox">
+                                            <input
+                                                    ng-mousedown="filter.switchCheckDown('mission')"
+                                                    ng-change = "filter.doUpdateOnNoChange('mission')"
+                                                    ng-model = "filter.missionIdCheck"
+                                                    type="checkbox">
                                         </span>
                                         <input
                                                 class = "form-control"
@@ -252,7 +257,8 @@
                                     <div class = "input-group input-group-sm">
                                         <span class = "input-group-addon">
                                             <input
-                                                    ng-change="filter.updateFilterString()"
+                                                    ng-mousedown="filter.switchCheckDown('product')"
+                                                    ng-change = "filter.doUpdateOnNoChange('product')"
                                                     ng-disabled = "!filter.imageryCheck"
                                                     ng-model="filter.productIdCheck"
                                                     type="checkbox">
@@ -282,7 +288,8 @@
                                     <div class = "input-group input-group-sm">
                                         <span class = "input-group-addon">
                                             <input
-                                                    ng-change = "filter.updateFilterString()"
+                                                    ng-mousedown="filter.switchCheckDown('sensor')"
+                                                    ng-change = "filter.doUpdateOnNoChange('sensor')"
                                                     ng-model = "filter.sensorIdCheck"
                                                     type = "checkbox">
                                         </span>


### PR DESCRIPTION
In omar-ui, when you select a feature dropdown and pick an option, if you click the checkbox, it switches on, does an updateFilterString() call and then flicks off when you release over the button, calling updateFilterString() a second time.

I fixed the issue by adding an onmousedown event for each checkbox element.