### PR TITLE
Video navbar bug

### DIFF
--- a/apps/omar-ui-app/grails-app/assets/javascripts/omar/filter/filter.controller.es6
+++ b/apps/omar-ui-app/grails-app/assets/javascripts/omar/filter/filter.controller.es6
@@ -65,7 +65,6 @@ function (
         });
     };
 
-
     /**
      * generates $scope.videoData = res.data
      * which is available to the app

--- a/apps/omar-ui-app/grails-app/assets/javascripts/omar/filter/filter.controller.es6
+++ b/apps/omar-ui-app/grails-app/assets/javascripts/omar/filter/filter.controller.es6
@@ -76,7 +76,7 @@ function (
      */
     vm.getVideos = function() {
         // Clear videoData each time
-        $scope.videoData = []
+        // $scope.videoData = []
         const baseUrl = stateService.omarSitesState.url.base
 
         // Only run this if the toggle (checkbox) is true
@@ -119,8 +119,8 @@ function (
                     // used for totals and pagination slicage.
                     // never altered!
                     $scope.videoData = res.data;
-
                     // get the first 10 results sliced up for page 1
+                    console.log("setting sliced");
                     $scope.slicedVideoData = $scope.videoData.features.slice(0, vm.pageLimit)
                 });
         }

--- a/apps/omar-ui-app/grails-app/assets/javascripts/omar/filter/filter.controller.es6
+++ b/apps/omar-ui-app/grails-app/assets/javascripts/omar/filter/filter.controller.es6
@@ -76,7 +76,6 @@ function (
      */
     vm.getVideos = function() {
         // Clear videoData each time
-        // $scope.videoData = []
         const baseUrl = stateService.omarSitesState.url.base
 
         // Only run this if the toggle (checkbox) is true
@@ -120,7 +119,6 @@ function (
                     // never altered!
                     $scope.videoData = res.data;
                     // get the first 10 results sliced up for page 1
-                    console.log("setting sliced");
                     $scope.slicedVideoData = $scope.videoData.features.slice(0, vm.pageLimit)
                 });
         }
@@ -142,6 +140,7 @@ function (
     vm.showCurrentFilter = true;
     vm.refreshSpin = false;
     vm.refreshList = function() {
+        vm.getVideos();
         wfsService.executeWfsQuery();
         vm.refreshSpin = true;
     };

--- a/apps/omar-ui-app/grails-app/assets/javascripts/omar/list/list.controller.es6
+++ b/apps/omar-ui-app/grails-app/assets/javascripts/omar/list/list.controller.es6
@@ -471,8 +471,6 @@
     vm.currentStartIndex = 1;
     vm.pageLimit = 10
 
-    vm.currentVideoPage = 1;
-
     // takes curPage param, which is bound pagination ng-model (1, 2, 3, 4, etc)
     // create the pagination range (pageLimit is typically 10)
     vm.videoPageChange = function(curPage) {

--- a/apps/omar-ui-app/grails-app/assets/javascripts/omar/list/list.controller.es6
+++ b/apps/omar-ui-app/grails-app/assets/javascripts/omar/list/list.controller.es6
@@ -475,14 +475,19 @@
     // create the pagination range (pageLimit is typically 10)
     vm.videoPageChange = function(curPage) {
       $scope.curVidStartInd = curPage * vm.pageLimit - vm.pageLimit
+      console.log("start index: " + $scope.curVidStartInd);
     }
 
     $scope.$watch('curVidStartInd', function() {
       // Kills function on page load.  Watchers fire on init
       if ($scope.videoData.length === 0){
+        console.log("length is zero");
         return
       }
       // Slice up videoData into chunks of 10 for pagination
+      if (typeof $scope.curVidStartInd === 'undefined')
+        $scope.curVidStartInd = 0;
+
       $scope.slicedVideoData = $scope.videoData.features.slice($scope.curVidStartInd, $scope.curVidStartInd + vm.pageLimit)
       $("#video-list").animate(
           {

--- a/apps/omar-ui-app/grails-app/assets/javascripts/omar/list/list.controller.es6
+++ b/apps/omar-ui-app/grails-app/assets/javascripts/omar/list/list.controller.es6
@@ -471,17 +471,17 @@
     vm.currentStartIndex = 1;
     vm.pageLimit = 10
 
+    vm.currentVideoPage = 1;
+
     // takes curPage param, which is bound pagination ng-model (1, 2, 3, 4, etc)
     // create the pagination range (pageLimit is typically 10)
     vm.videoPageChange = function(curPage) {
       $scope.curVidStartInd = curPage * vm.pageLimit - vm.pageLimit
-      console.log("start index: " + $scope.curVidStartInd);
     }
 
     $scope.$watch('curVidStartInd', function() {
       // Kills function on page load.  Watchers fire on init
       if ($scope.videoData.length === 0){
-        console.log("length is zero");
         return
       }
       // Slice up videoData into chunks of 10 for pagination

--- a/apps/omar-ui-app/grails-app/assets/javascripts/omar/services/video.service.es6
+++ b/apps/omar-ui-app/grails-app/assets/javascripts/omar/services/video.service.es6
@@ -28,7 +28,7 @@ function($http, stateService) { return {
         }
 
         const queryString = Object.keys(wfsParams).map(key => key + '=' + wfsParams[key]).join('&');
-        console.log("video query url: " + (wfsUrl + queryString));
+
         return $http({
             method: "GET",
             url: wfsUrl + queryString

--- a/apps/omar-ui-app/grails-app/assets/javascripts/omar/services/video.service.es6
+++ b/apps/omar-ui-app/grails-app/assets/javascripts/omar/services/video.service.es6
@@ -9,7 +9,6 @@ function($http, stateService) { return {
     videoQuery: function (startIndex = 0, maxFeatures = 100) {
         // console.log('executing query... params:', params)
         const baseUrl = stateService.omarSitesState.url.base
-        console.log("baseUrl: " + baseUrl);
         // console.log("mey baseUrl: " + stateService.omarSitesState.url.base);
         let urlParams = new URLSearchParams(window.location.search)
         // let filter = urlParams.get('filter')
@@ -29,7 +28,7 @@ function($http, stateService) { return {
         }
 
         const queryString = Object.keys(wfsParams).map(key => key + '=' + wfsParams[key]).join('&');
-
+        console.log("video query url: " + (wfsUrl + queryString));
         return $http({
             method: "GET",
             url: wfsUrl + queryString

--- a/apps/omar-ui-app/grails-app/assets/javascripts/omar/services/wfs.service.es6
+++ b/apps/omar-ui-app/grails-app/assets/javascripts/omar/services/wfs.service.es6
@@ -198,7 +198,6 @@ function (stateService, $http, $injector, $log, $rootScope, $timeout, $sce) {
                     extraParam = { maxFeatures: wfsRequest.pageLimit };
 
                     if ( wfsAjax.features ) {
-                        // console.log('wfsAjax.features', wfsAjax.features)
                         wfsAjax.features.abort();
                     }
                     wfsAjax.features = wfsQuery();
@@ -332,7 +331,6 @@ function (stateService, $http, $injector, $log, $rootScope, $timeout, $sce) {
      * @param id
      */
     this.getImagesExtent = id => {
-        console.log("this was called");
       let version = "1.1.0";
       let typeName = "omar:raster_entry";
 
@@ -363,7 +361,6 @@ function (stateService, $http, $injector, $log, $rootScope, $timeout, $sce) {
 
       return $http({ method: "GET", url: wfsUrl }).then(function(response) {
         var features = response.data.features;
-        console.log('main features', features)
         return features;
       });
     };

--- a/apps/omar-ui-app/grails-app/views/views/map/_map.partial.html.gsp
+++ b/apps/omar-ui-app/grails-app/views/views/map/_map.partial.html.gsp
@@ -56,7 +56,7 @@
                     <input
                         type="checkbox"
                         ng-model="filterVideosToggle"
-                        ng-change="filter.getVideos(filterVideosToggle); filter.handleNonVideoFilters(); filter.clearFilters()"
+                        ng-change="filter.getVideos(); filter.handleNonVideoFilters(); filter.clearFilters()"
                     > Videos Only
                 </div>
 


### PR DESCRIPTION
I noticed the navbar for video would expand and then shrink back whenever you switch to video or change the server. Basically, anytime the videos change.

My fix was to remove the `$scope.videoData = [] in getVideos()`, that way the content only changes after the query is made. I had to add a couple other things for it to work. But currently this works, and I don't believe it messes with anything necessary. (hopefully haha)