### PR TITLE
Removed sonarqube login override

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,8 +126,7 @@ node(POD_LABEL){
                 withSonarQubeEnv('sonarqube'){
                     sh """
                         ${scannerHome}/bin/sonar-scanner \
-                        -Dsonar.projectKey=${APP_NAME} \
-                        -Dsonar.login=${SONARQUBE_TOKEN}
+                        -Dsonar.projectKey=${APP_NAME}
                     """
             }
         }


### PR DESCRIPTION
SonarQube env 'sonarqube' has login and password, does not need to be overwritten